### PR TITLE
Add local mq_prometheus configuration example

### DIFF
--- a/mq_prometheus/README.md
+++ b/mq_prometheus/README.md
@@ -1,0 +1,19 @@
+# mq_prometheus local configuration
+
+This directory provides an example configuration file for the `mq_prometheus` collector that connects to an IBM MQ queue manager using a local (bindings) connection.
+
+## Configuration
+
+`mq_prometheus.yaml` combines the common settings from [`config.common.yaml`](../config.common.yaml) with the Prometheus options defined in [`cmd/mq_prometheus/config.collector.yaml`](../cmd/mq_prometheus/config.collector.yaml). It assumes the collector runs on the same host as the queue manager. Update `connection.queueManager` if your queue manager name differs.
+
+The `prometheus` section also supports optional attributes such as `host`, `httpsCertFile`/`httpsKeyFile` for TLS, and `overrideCType` for controlling metric types; see [`cmd/mq_prometheus/config.go`](../cmd/mq_prometheus/config.go) for the full list of properties.
+
+## Running the collector
+
+Execute the collector and point it at the configuration file:
+
+```sh
+mq_prometheus -f mq_prometheus.yaml
+```
+
+The Prometheus endpoint will be available on port `9157` and exposes metrics at `/metrics`.

--- a/mq_prometheus/mq_prometheus.yaml
+++ b/mq_prometheus/mq_prometheus.yaml
@@ -1,0 +1,48 @@
+global:
+  useObjectStatus: true
+  useResetQStats: false
+  usePublications: true
+  logLevel: INFO
+  metaprefix: ""
+  pollInterval: 30s
+  rediscoverInterval: 1h
+  tzOffset: 0h
+
+connection:
+  queueManager: QM1
+  # Local bindings connection; ensure the program runs on the same host as the queue manager
+  clientConnection: false
+  replyQueue: SYSTEM.DEFAULT.MODEL.QUEUE
+
+objects:
+  queues:
+    - APP.*
+    - "!SYSTEM.*"
+    - "!AMQ.*"
+    - QM*
+  channels:
+    - SYSTEM.*
+    - TO.*
+  topics:
+  subscriptions:
+
+filters:
+  hideSvrConnJobname: false
+  showInactiveChannels: false
+  hideAMQPClientId: false
+  hideMQTTClientId: false
+  queueSubscriptionSelector:
+    - PUT
+    - GET
+    - GENERAL
+
+prometheus:
+  port: 9157
+  # host: 127.0.0.1 # Bind HTTP server to a specific interface
+  metricsPath: "/metrics"
+  namespace: ibmmq
+  # httpsCertFile: server.crt
+  # httpsKeyFile: server.key
+  keepRunning: true
+  reconnectInterval: 5s
+  # overrideCType: ""


### PR DESCRIPTION
## Summary
- provide example configuration for `mq_prometheus` using local bindings
- document usage in new README
- note optional Prometheus configuration values

## Testing
- `go vet ./...` (fails: `cmqc.h: No such file or directory`)


------
https://chatgpt.com/codex/tasks/task_e_689e2f3daf088325b218cd7abffc59b3